### PR TITLE
Allow fetchRepos running with different GH API versions

### DIFF
--- a/fetchRepos.js
+++ b/fetchRepos.js
@@ -376,7 +376,7 @@ optional arguments:
     }
 
     async function fetchRepoLanguages(repo) {
-      spinner = ora(`Fetching ${repo.full_name}...`).start();
+      spinner = ora(`Fetching ${repo.full_name}'s languages...`).start();
 
       if (!repo.fetching_since || repo.fetched_at &&
           new Date(repo.fetched_at) > new Date(repo.pushed_at)) {
@@ -392,7 +392,7 @@ optional arguments:
         return;
       }
 
-      spinner.succeed(`Fetched ${repo.full_name}`);
+      spinner.succeed(`Fetched ${repo.full_name}'s languages`);
 
       for (let language in ghDataJson) {
         ghDataJson[language] = {

--- a/impl/fetchJson.js
+++ b/impl/fetchJson.js
@@ -6,7 +6,7 @@
   const fetch = require('fetch-retry');
 
   const fetchJson = async function(url, oraSpinner, acceptedErrorCodes=[],
-                                   /*Date*/ifModifiedSince, graphqlQuery) {
+                                   /*Date*/ifModifiedSince, bodyObject) {
     // If the HTTP status code is 2xx, returns the object represented by the fetched json.
     // Else if the HTTP status code is in acceptedErrorCodes, returns it.
     // Else throws the HTTP status code.
@@ -18,10 +18,8 @@
         headers: ifModifiedSince && {
           'If-Modified-Since': ifModifiedSince.toUTCString()
         } || null,
-        method: graphqlQuery && 'POST' || 'GET',
-        body: graphqlQuery && JSON.stringify({
-          query: graphqlQuery
-        })
+        method: bodyObject && 'POST' || 'GET',
+        body: bodyObject && JSON.stringify(bodyObject)
       });
     } catch (e) { // we end up here after too many retries
       data = e;
@@ -48,6 +46,7 @@
           break;
         }
       }
+
       throw data.status;
     }
 

--- a/impl/githubV3.js
+++ b/impl/githubV3.js
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+'use strict';
+
+(() => {
+
+  const gh = require('./github');
+
+  const repo = async (oraSpinner, errCodes, repoFullName, repoFetchedAtDate) => {
+    const ghRepoUrl = `https://api.github.com/repos/${repoFullName}`;
+    return await gh.fetchGHJson(ghRepoUrl, oraSpinner, errCodes, repoFetchedAtDate);
+  };
+
+  const commits = async (oraSpinner, errCodes, repoFullName, lastFetchedCommitDateStr, page, perPage) => {
+    const ghUrl = `https://api.github.com/repos/${repoFullName}/commits?since=${lastFetchedCommitDateStr}&page=${page}&per_page=${perPage}`;
+    return await gh.fetchGHJson(ghUrl, oraSpinner, errCodes);
+  }
+
+  const pullRequests = async (oraSpinner, errCodes, repoFullName, page, perPage) => {
+    const ghUrl = `https://api.github.com/repos/${repoFullName}/pulls?state=all&page=${page}&per_page=${perPage}`;
+    return await gh.fetchGHJson(ghUrl, oraSpinner, errCodes);
+  }
+
+  const repoLanguages = async (oraSpinner, errCodes, repoFullName) => {
+    const ghUrl = `https://api.github.com/repos/${repoFullName}/languages`;
+    return await gh.fetchGHJson(ghUrl, oraSpinner, errCodes);
+  }
+
+  module.exports = {
+    repo,
+    commits,
+    pullRequests,
+    repoLanguages,
+  };
+
+})();

--- a/impl/githubV4.js
+++ b/impl/githubV4.js
@@ -1,0 +1,292 @@
+#!/usr/bin/env node
+
+'use strict';
+
+(() => {
+
+  const gh = require('./github');
+
+  const repoQuery = `
+query($owner: String!, $name: String!) {
+  repository(owner: $owner, name: $name) {
+    name
+    nameWithOwner
+    isPrivate
+    owner {
+      login
+    }
+    url
+    description
+    isFork
+    createdAt
+    updatedAt
+    pushedAt
+    homepageUrl
+    diskUsage
+    stargazers {
+      totalCount
+    }
+    primaryLanguage {
+      name
+    }
+    mirrorUrl
+    isArchived
+    licenseInfo {
+      key
+      name
+      spdxId
+      url
+      id
+    }
+    defaultBranchRef {
+      name
+    }
+    languages(first: 100) {
+      edges {
+        size
+        node {
+          color
+          name
+        }
+      }
+    }
+  }
+}
+`
+  const repo = async (oraSpinner, errCodes, repoFullName, repoFetchedAtDate) => {
+    // TODO use repoFetchedAtDate
+
+    const dataJson = await gh.fetchGHJson('https://api.github.com/graphql', oraSpinner, errCodes, null, {
+      query: repoQuery,
+      variables: buildCommonRepoVariables(repoFullName),
+    })
+
+    if (!(dataJson instanceof Object)) {
+      return dataJson
+    }
+    if (dataJson.errors) {
+      switch (dataJson.errors[0].type) {
+        case "NOT_FOUND":
+          return 404
+      }
+    }
+
+    const r = dataJson.data.repository
+
+    let res = {}
+    res.name = r.name
+    res.full_name = r.nameWithOwner
+    res.private = r.isPrivate
+    res.owner = r.owner.login
+    res.html_url = r.url
+    res.description = r.description
+    res.fork = r.isFork
+    res.url = "https://api.github.com/repos/" + r.nameWithOwner
+    res.languages_url = "https://api.github.com/repos/" + r.nameWithOwner + "/languages"
+    res.pulls_url = "https://api.github.com/repos/" + r.nameWithOwner + "/pulls{/number}"
+
+    // format: "2015-09-10T02:15:47Z"
+    res.created_at = coerceDate(r.createdAt)
+    res.updated_at = coerceDate(r.updatedAt)
+    res.pusher_at = coerceDate(r.pushedAt)
+
+    res.homepage = r.homepageUrl // TODO verify expected URL
+    res.size = r.diskUsage
+    res.stargazers_count = r.stargazers.totalCount
+    res.language = r.primaryLanguage.name
+    res.mirror_url = r.mirrorUrl
+    res.archived = r.isArchived
+    res.default_branch = r.defaultBranchRef.name
+
+    if (r.licenseInfo) {
+      res.license = {}
+      res.license.key  = r.licenseInfo.key
+      res.license.name  = r.licenseInfo.name
+      res.license.spdx_id  = r.licenseInfo.spdxId
+      res.license.url  = r.licenseInfo.url
+      res.license.node_id  = r.licenseInfo.id
+    }
+
+    res.languages = {}
+    for (let it of r.languages.edges) {
+      res.languages[it.node.name] = {
+        bytes: it.size,
+        color: it.node.color,
+      }
+    }
+
+    return res
+  };
+
+  const commitsQuery = `
+query($owner: String!, $name: String!, $cursor: String, $since: GitTimestamp) {
+  repository(owner: $owner, name: $name) {
+    ref(qualifiedName: "master") {
+      target {
+        ... on Commit {
+          history(since: $since, first: 100, after: $cursor) {
+            edges {
+              node {
+                oid
+                author {
+                  date
+                  user {
+                    login
+                  }
+                }
+                committer {
+                  date
+                  user {
+                    login
+                  }
+                }
+              }
+              cursor
+            }
+          }
+        }
+      }
+    }
+  }
+}
+`
+  const commits = async (oraSpinner, errCodes, repoFullName, lastFetchedCommitDateStr, page, perPage, v4cursor = null) => {
+
+    let variables = buildCommonRepoVariables(repoFullName, page, v4cursor)
+    variables.since = lastFetchedCommitDateStr
+    const dataJson = await gh.fetchGHJson('https://api.github.com/graphql', oraSpinner, errCodes, null, {
+      query: commitsQuery,
+      variables: variables,
+    })
+
+    if (!(dataJson instanceof Object)) {
+      return dataJson
+    }
+
+    let edges = dataJson.data.repository.ref.target.history.edges
+
+    let res = []
+    for (let e of edges) {
+      const author = e.node.author
+      const committer = e.node.committer
+
+      res.push({
+        sha: e.node.oid,
+        commit: {
+          author: {
+            date: coerceDate(author.date),
+          },
+          committer: {
+            date: coerceDate(committer.date),
+          },
+        },
+        author: {
+          login: author.user ? author.user.login : null,
+        },
+        committer: {
+          login: committer.user ? committer.user.login : null,
+        },
+      })
+    }
+
+    insertCursor(res, edges)
+
+    return res
+  };
+
+  const pullRequestsQuery = `
+query($owner: String!, $name: String!, $cursor: String) {
+  repository(owner: $owner, name: $name) {
+    pullRequests(first: 100, orderBy: {field: CREATED_AT, direction: DESC}, after: $cursor) {
+      edges {
+        cursor
+        node {
+          createdAt
+          author {
+            login
+          }
+        }
+      }
+    }
+  }
+}
+`
+  const pullRequests = async (oraSpinner, errCodes, repoFullName, page, perPage, v4cursor = null) => {
+
+    const dataJson = await gh.fetchGHJson('https://api.github.com/graphql', oraSpinner, errCodes, null, {
+      query: pullRequestsQuery,
+      variables: buildCommonRepoVariables(repoFullName, page, v4cursor),
+    })
+
+    if (!(dataJson instanceof Object)) {
+      return dataJson
+    }
+
+    let edges = dataJson.data.repository.pullRequests.edges
+
+    let res = []
+    for (let e of edges) {
+      res.push({
+          user: {
+            login: e.node.author ? e.node.author.login : null,
+          }
+      })
+    }
+
+    insertCursor(res, edges)
+
+    return res
+  }
+
+  const repoLanguages = async () => {
+    throw "unexpected call to repoLanguages"
+    return
+  }
+
+  module.exports = {
+    repo,
+    commits,
+    pullRequests,
+    repoLanguages,
+  }
+
+  function buildCommonRepoVariables(repoFullName, page, cursor) {
+    let owner, repoName
+    [owner, repoName] = repoFullName.split("/")
+
+    let variables = {
+      owner: owner,
+      name: repoName,
+    }
+
+    if (isNaN(page) || page === 1) {
+      return variables
+    }
+
+    if (cursor == null) {
+      throw "expected cursor not null"
+    }
+
+    variables.cursor = cursor
+
+    return variables
+  }
+
+  // TODO: Find better way.
+  // Pass the cursor in the first element of the response.
+  function insertCursor(resultArray, edgesArray) {
+    if (resultArray.length > 0 && edgesArray.length > 0) {
+      const cursor = edgesArray.slice(-1)[0].cursor
+      console.log(cursor)
+      resultArray[0].cursor = cursor
+    }
+  }
+
+  function coerceDate(dateStr) {
+    if (!dateStr) {
+      return dateStr
+    }
+    return (new Date(dateStr)).toISOString()
+  }
+
+})();


### PR DESCRIPTION
* Allow `fetchRepos` running different API versions of GitHub API while. Behaviour when running with API v3 should be unchanged.
* Implements a beta of GitHub API v4 that still needs to be tested.

Refactorings:
* In `fetchRepos.js`: In order to allow using indifferently GitHub API v3 or v4, GitHub API calls are abstracted by an interface. The original V3 implementation is now in `impl/githubV3`
* In `impl/github.js`: Change the API of `fetchGHJson` — only the case a `graphqlQuery` is given — to pass the whole response object instead of just data.
* In `impl/fetchJson.js`: Make it unaware of Graph QL concepts — Affects only the v4 case.

Features:
* `impl/githubV4.js` implements the adapter for the V4 API. Use environment variable `GHUSER_GHV4=true` to enable it.

Limitations:
* v4 doesn't fill the `organization` field of the `repo` query.
* The abstraction of the GitHub API leaks a detail — A `cursor` is required by v4 and not by v3, it's not been yet encapsulated.
* Running the script with V4 gave similar results than V3 on a manual test with one user, but it's not yet been exhaustively tested.

Tests:
* Running the v3 from the PR branch is giving the same results as running it from master (compared the db on 1 user).