### PR TITLE
fetchRepo runs GitHub API v3 and v4 concurrently

### DIFF
--- a/fetchRepos.js
+++ b/fetchRepos.js
@@ -109,12 +109,12 @@ optional arguments:
     }
     spinner.succeed(`Found ${Object.keys(repoPaths).length} repos in DB`);
 
+    stripUnreferencedRepos();
+
     // We iterate over referencedRepos and not repoPath because new repositories might have been created.
     for (const repoFullName of referencedRepos) {
       await fetchRepo(repoFullName, firsttime);
     }
-
-    stripUnreferencedRepos();
 
     for (const repoFullName in repoPaths) {
       const repo = new DbFile(repoPaths[repoFullName].repo);

--- a/fetchRepos.js
+++ b/fetchRepos.js
@@ -136,7 +136,6 @@ optional arguments:
 
       console.log(`${tag} starting`);
       const repo = new DbFile(repoPaths[repoFullName].repo);
-      // repo.gh_api_version = ghcl.version;
 
       const now = new Date;
       const maxAgeHours = firsttime && (24 * 365) || 12;
@@ -229,8 +228,6 @@ optional arguments:
       const tag = `[${ghcl.version}] Fetch Commits & Contribs - ${repo.full_name} -`;
 
       repo.contributors = repo.contributors || {};
-      // repo.gh_api_version_constributors = ghcl.version;
-      repoCommits.version_constributors = ghcl.version;
       repoCommits.contributors = repoCommits.contributors || {};
       repoCommits.last_fetched_commit = repoCommits.last_fetched_commit || {
         sha: null,
@@ -344,7 +341,6 @@ optional arguments:
     async function fetchRepoPullRequests(ghcl, repo) {
       const tag = `[${ghcl.version}] Fetch PRs - ${repo.full_name} -`;
 
-      // repo.gh_api_version_pulls = ghcl.version;
       console.log(`${tag} starting`);
 
       if (!repo.fetching_since || repo.fetched_at &&
@@ -402,7 +398,6 @@ optional arguments:
     async function fetchRepoLanguages(ghcl, repo) {
       const tag = `[${ghcl.version}] Fetch Languages - ${repo.full_name} -`;
 
-      // repo.gh_api_version_languages = ghcl.version;
       console.log(`${tag} starting`);
 
       if (!repo.fetching_since || repo.fetched_at &&

--- a/fetchRepos.js
+++ b/fetchRepos.js
@@ -109,9 +109,11 @@ optional arguments:
     }
     spinner.succeed(`Found ${Object.keys(repoPaths).length} repos in DB`);
 
+    // We iterate over referencedRepos and not repoPath because new repositories might have been created.
     for (const repoFullName of referencedRepos) {
       await fetchRepo(repoFullName, firsttime);
     }
+
     stripUnreferencedRepos();
 
     for (const repoFullName in repoPaths) {

--- a/fetchRepos.js
+++ b/fetchRepos.js
@@ -264,7 +264,7 @@ optional arguments:
             repoCommits.ghuser_truncated = true;
             break pages;
           }
-          console.log(`${tag} failed.`);
+          console.log(`${tag} failed`);
           return;
         }
 

--- a/impl/data.js
+++ b/impl/data.js
@@ -8,7 +8,7 @@
   const dbPath = process.env.GHUSER_DBDIR || path.join(os.homedir(), 'data');
 
   if (!fs.existsSync(dbPath)) {
-    throw `${dbPath} directory doesn't exist`
+    throw `${dbPath} directory doesn't exist`;
   }
 
   module.exports = {

--- a/impl/github.js
+++ b/impl/github.js
@@ -57,12 +57,12 @@
   // Returns GitHub's rate limit object for reference.
   async function waitForRateLimit(oraSpinner, isGraphQL) {
     const oldSpinnerText = oraSpinner && oraSpinner.text;
+    const key = isGraphQL ? "graphql" : "core";
 
     let rateLimit = await fetchGHRateLimit(oraSpinner);
-    const lim = rateLimit[isGraphQL ? "graphql" : "core"]
-    if (lim.remaining <= 10) {
+    if (rateLimit[key].remaining <= 10) {
       const now = (new Date).getTime() / 1000;
-      const secondsToSleep = Math.ceil(lim.reset - now) + 1;
+      const secondsToSleep = Math.ceil(rateLimit[key].reset - now) + 1;
       if (secondsToSleep >= 0) {
         if (oraSpinner) {
           oraSpinner.text += ` (waiting ${secondsToSleep} second(s) for API rate limit)`;
@@ -70,10 +70,10 @@
 
         await sleep(secondsToSleep * 1000);
         rateLimit = await fetchGHRateLimit(oraSpinner);
-        if (lim.remaining <= 10) {
+        if (rateLimit[key].remaining <= 10) {
           console.error('\nAPI rate limit is still low:');
           console.error(rateLimit);
-          console.error(`next reset in ${Math.ceil(lim.reset - ((new Date).getTime() / 1000))} seconds(s)`);
+          console.error(`next reset in ${Math.ceil(rateLimit[key].reset - ((new Date).getTime() / 1000))} seconds(s)`);
           throw 'API rate limit is still low after waiting';
         }
 

--- a/impl/githubV3.js
+++ b/impl/githubV3.js
@@ -5,27 +5,30 @@
 
   const gh = require('./github');
 
-  const repo = async (oraSpinner, errCodes, repoFullName, repoFetchedAtDate) => {
+  const version = "V3";
+
+  const repo = async (errCodes, repoFullName, repoFetchedAtDate) => {
     const ghRepoUrl = `https://api.github.com/repos/${repoFullName}`;
-    return await gh.fetchGHJson(ghRepoUrl, oraSpinner, errCodes, repoFetchedAtDate);
+    return await gh.fetchGHJson(ghRepoUrl, null, errCodes, repoFetchedAtDate);
   };
 
-  const commits = async (oraSpinner, errCodes, repoFullName, lastFetchedCommitDateStr, page, perPage) => {
+  const commits = async (errCodes, repoFullName, lastFetchedCommitDateStr, page, perPage) => {
     const ghUrl = `https://api.github.com/repos/${repoFullName}/commits?since=${lastFetchedCommitDateStr}&page=${page}&per_page=${perPage}`;
-    return await gh.fetchGHJson(ghUrl, oraSpinner, errCodes);
-  }
+    return await gh.fetchGHJson(ghUrl, null, errCodes);
+  };
 
-  const pullRequests = async (oraSpinner, errCodes, repoFullName, page, perPage) => {
+  const pullRequests = async (errCodes, repoFullName, page, perPage) => {
     const ghUrl = `https://api.github.com/repos/${repoFullName}/pulls?state=all&page=${page}&per_page=${perPage}`;
-    return await gh.fetchGHJson(ghUrl, oraSpinner, errCodes);
-  }
+    return await gh.fetchGHJson(ghUrl, null, errCodes);
+  };
 
-  const repoLanguages = async (oraSpinner, errCodes, repoFullName) => {
+  const repoLanguages = async (errCodes, repoFullName) => {
     const ghUrl = `https://api.github.com/repos/${repoFullName}/languages`;
-    return await gh.fetchGHJson(ghUrl, oraSpinner, errCodes);
-  }
+    return await gh.fetchGHJson(ghUrl, null, errCodes);
+  };
 
   module.exports = {
+    version,
     repo,
     commits,
     pullRequests,

--- a/impl/githubV4.js
+++ b/impl/githubV4.js
@@ -54,7 +54,8 @@ query($owner: String!, $name: String!) {
 }
 `
   const repo = async (oraSpinner, errCodes, repoFullName, repoFetchedAtDate) => {
-    // TODO use repoFetchedAtDate
+    // TODO: Use repoFetchedAtDate
+    // TODO: This doesn't fetch "organization" as v3 does. Check if it's a problem.
 
     const dataJson = await gh.fetchGHJson('https://api.github.com/graphql', oraSpinner, errCodes, null, {
       query: repoQuery,

--- a/impl/githubV4.js
+++ b/impl/githubV4.js
@@ -83,7 +83,7 @@ query($owner: String!, $name: String!) {
     res.homepage = r.homepageUrl; // TODO verify expected URL
     res.size = r.diskUsage;
     res.stargazers_count = r.stargazers.totalCount;
-    res.language = r.primaryLanguage.name;
+    res.language = r.primaryLanguage ? r.primaryLanguage.name : null;
     res.mirror_url = r.mirrorUrl;
     res.archived = r.isArchived;
 

--- a/impl/githubV4.js
+++ b/impl/githubV4.js
@@ -6,6 +6,8 @@
 
   const gh = require('./github');
 
+  const version = "V4";
+
   const repoQuery = `
 query($owner: String!, $name: String!) {
   repository(owner: $owner, name: $name) {
@@ -14,6 +16,7 @@ query($owner: String!, $name: String!) {
     isPrivate
     owner {
       login
+      __typename
     }
     url
     description
@@ -41,79 +44,62 @@ query($owner: String!, $name: String!) {
     defaultBranchRef {
       name
     }
-    languages(first: 100) {
-      edges {
-        size
-        node {
-          color
-          name
-        }
-      }
-    }
   }
 }
-`
-  const repo = async (oraSpinner, errCodes, repoFullName, repoFetchedAtDate) => {
+`;
+  // TODO: This sets "organization" field if appropriate, but as an empty object.
+  const repo = async (errCodes, repoFullName, repoFetchedAtDate) => {
     // TODO: Use repoFetchedAtDate
-    // TODO: This doesn't fetch "organization" as v3 does. Check if it's a problem.
 
-    const dataJson = await gh.fetchGHJson('https://api.github.com/graphql', oraSpinner, errCodes, null, {
+    const dataJson = await gh.fetchGHJson('https://api.github.com/graphql', null, errCodes, null, {
       query: repoQuery,
       variables: buildCommonRepoVariables(repoFullName),
-    })
+    });
 
-    if (!(dataJson instanceof Object)) {
-      return dataJson
-    }
-    if (dataJson.errors) {
-      switch (dataJson.errors[0].type) {
-        case "NOT_FOUND":
-          return 404
-      }
+    const err = checkResponse(dataJson);
+    if (err != null) {
+      return err
     }
 
-    const r = dataJson.data.repository
+    const r = dataJson.data.repository;
 
-    let res = {}
-    res.name = r.name
-    res.full_name = r.nameWithOwner
-    res.private = r.isPrivate
-    res.owner = r.owner.login
-    res.html_url = r.url
-    res.description = r.description
-    res.fork = r.isFork
-    res.url = "https://api.github.com/repos/" + r.nameWithOwner
-    res.languages_url = "https://api.github.com/repos/" + r.nameWithOwner + "/languages"
-    res.pulls_url = "https://api.github.com/repos/" + r.nameWithOwner + "/pulls{/number}"
+    let res = {};
+    res.name = r.name;
+    res.full_name = r.nameWithOwner;
+    res.private = r.isPrivate;
+    res.owner = r.owner.login;
+    res.html_url = r.url;
+    res.description = r.description;
+    res.fork = r.isFork;
+    res.url = "https://api.github.com/repos/" + r.nameWithOwner;
+    res.languages_url = "https://api.github.com/repos/" + r.nameWithOwner + "/languages";
+    res.pulls_url = "https://api.github.com/repos/" + r.nameWithOwner + "/pulls{/number}";
 
     // format: "2015-09-10T02:15:47Z"
-    res.created_at = coerceDate(r.createdAt)
-    res.updated_at = coerceDate(r.updatedAt)
-    res.pusher_at = coerceDate(r.pushedAt)
+    res.created_at = coerceDate(r.createdAt);
+    res.updated_at = coerceDate(r.updatedAt);
+    res.pusher_at = coerceDate(r.pushedAt);
 
-    res.homepage = r.homepageUrl // TODO verify expected URL
-    res.size = r.diskUsage
-    res.stargazers_count = r.stargazers.totalCount
-    res.language = r.primaryLanguage.name
-    res.mirror_url = r.mirrorUrl
-    res.archived = r.isArchived
-    res.default_branch = r.defaultBranchRef.name
+    res.homepage = r.homepageUrl; // TODO verify expected URL
+    res.size = r.diskUsage;
+    res.stargazers_count = r.stargazers.totalCount;
+    res.language = r.primaryLanguage.name;
+    res.mirror_url = r.mirrorUrl;
+    res.archived = r.isArchived;
 
     if (r.licenseInfo) {
-      res.license = {}
-      res.license.key  = r.licenseInfo.key
-      res.license.name  = r.licenseInfo.name
-      res.license.spdx_id  = r.licenseInfo.spdxId
-      res.license.url  = r.licenseInfo.url
-      res.license.node_id  = r.licenseInfo.id
+      res.license = {};
+      res.license.key  = r.licenseInfo.key;
+      res.license.name  = r.licenseInfo.name;
+      res.license.spdx_id  = r.licenseInfo.spdxId;
+      res.license.url  = r.licenseInfo.url;
+      res.license.node_id  = r.licenseInfo.id;
     }
 
-    res.languages = {}
-    for (let it of r.languages.edges) {
-      res.languages[it.node.name] = {
-        bytes: it.size,
-        color: it.node.color,
-      }
+    res.default_branch = r.defaultBranchRef.name;
+
+    if (r.owner.__typename === "Organization") {
+      res.organization = {};
     }
 
     return res
@@ -150,26 +136,26 @@ query($owner: String!, $name: String!, $cursor: String, $since: GitTimestamp) {
     }
   }
 }
-`
-  const commits = async (oraSpinner, errCodes, repoFullName, lastFetchedCommitDateStr, page, perPage, v4cursor = null) => {
+`;
+  const commits = async (errCodes, repoFullName, lastFetchedCommitDateStr, page, perPage, v4cursor = null) => {
 
-    let variables = buildCommonRepoVariables(repoFullName, page, v4cursor)
-    variables.since = lastFetchedCommitDateStr
-    const dataJson = await gh.fetchGHJson('https://api.github.com/graphql', oraSpinner, errCodes, null, {
+    let variables = buildCommonRepoVariables(repoFullName, page, v4cursor);
+    variables.since = lastFetchedCommitDateStr;
+    const dataJson = await gh.fetchGHJson('https://api.github.com/graphql', null, errCodes, null, {
       query: commitsQuery,
       variables: variables,
-    })
+    });
 
     if (!(dataJson instanceof Object)) {
       return dataJson
     }
 
-    let edges = dataJson.data.repository.ref.target.history.edges
+    let edges = dataJson.data.repository.ref.target.history.edges;
 
-    let res = []
+    let res = [];
     for (let e of edges) {
-      const author = e.node.author
-      const committer = e.node.committer
+      const author = e.node.author;
+      const committer = e.node.committer;
 
       res.push({
         sha: e.node.oid,
@@ -190,7 +176,7 @@ query($owner: String!, $name: String!, $cursor: String, $since: GitTimestamp) {
       })
     }
 
-    insertCursor(res, edges)
+    insertCursor(res, edges);
 
     return res
   };
@@ -211,21 +197,21 @@ query($owner: String!, $name: String!, $cursor: String) {
     }
   }
 }
-`
-  const pullRequests = async (oraSpinner, errCodes, repoFullName, page, perPage, v4cursor = null) => {
+`;
+  const pullRequests = async (errCodes, repoFullName, page, perPage, v4cursor = null) => {
 
-    const dataJson = await gh.fetchGHJson('https://api.github.com/graphql', oraSpinner, errCodes, null, {
+    const dataJson = await gh.fetchGHJson('https://api.github.com/graphql', null, errCodes, null, {
       query: pullRequestsQuery,
       variables: buildCommonRepoVariables(repoFullName, page, v4cursor),
-    })
+    });
 
     if (!(dataJson instanceof Object)) {
       return dataJson
     }
 
-    let edges = dataJson.data.repository.pullRequests.edges
+    let edges = dataJson.data.repository.pullRequests.edges;
 
-    let res = []
+    let res = [];
     for (let e of edges) {
       res.push({
           user: {
@@ -234,31 +220,64 @@ query($owner: String!, $name: String!, $cursor: String) {
       })
     }
 
-    insertCursor(res, edges)
+    insertCursor(res, edges);
 
     return res
-  }
+  };
 
-  const repoLanguages = async () => {
-    throw "unexpected call to repoLanguages"
-    return
+  const repoLanguagesQuery = `
+query($owner: String!, $name: String!) {
+  repository(owner: $owner, name: $name) {
+    languages(first: 100) {
+      edges {
+        size
+        node {
+          name
+        }
+      }
+    }
   }
+}
+`;
+  const repoLanguages = async (errCodes, repoFullName) => {
+
+    const dataJson = await gh.fetchGHJson('https://api.github.com/graphql', null, errCodes, null, {
+      query: repoLanguagesQuery,
+      variables: buildCommonRepoVariables(repoFullName),
+    });
+
+    const err = checkResponse(dataJson);
+    if (err != null) {
+      return err
+    }
+
+    const r = dataJson.data.repository;
+
+    let res = {};
+
+    for (let it of r.languages.edges) {
+      res[it.node.name] = it.size
+    }
+
+    return res
+  };
 
   module.exports = {
+    version,
     repo,
     commits,
     pullRequests,
     repoLanguages,
-  }
+  };
 
   function buildCommonRepoVariables(repoFullName, page, cursor) {
-    let owner, repoName
-    [owner, repoName] = repoFullName.split("/")
+    let owner, repoName;
+    [owner, repoName] = repoFullName.split("/");
 
     let variables = {
       owner: owner,
       name: repoName,
-    }
+    };
 
     if (isNaN(page) || page === 1) {
       return variables
@@ -268,7 +287,7 @@ query($owner: String!, $name: String!, $cursor: String) {
       throw "expected cursor not null"
     }
 
-    variables.cursor = cursor
+    variables.cursor = cursor;
 
     return variables
   }
@@ -277,8 +296,7 @@ query($owner: String!, $name: String!, $cursor: String) {
   // Pass the cursor in the first element of the response.
   function insertCursor(resultArray, edgesArray) {
     if (resultArray.length > 0 && edgesArray.length > 0) {
-      const cursor = edgesArray.slice(-1)[0].cursor
-      console.log(cursor)
+      const cursor = edgesArray.slice(-1)[0].cursor;
       resultArray[0].cursor = cursor
     }
   }
@@ -288,6 +306,21 @@ query($owner: String!, $name: String!, $cursor: String) {
       return dateStr
     }
     return (new Date(dateStr)).toISOString()
+  }
+
+  function checkResponse(dataJson) {
+    if (!(dataJson instanceof Object)) {
+      return 500
+    }
+    if (dataJson.errors) {
+      switch (dataJson.errors[0].type) {
+        case "NOT_FOUND":
+          return 404;
+        default:
+          return 500;
+      }
+    }
+    return null;
   }
 
 })();

--- a/impl/githubV4.js
+++ b/impl/githubV4.js
@@ -67,7 +67,9 @@ query($owner: String!, $name: String!) {
     res.name = r.name;
     res.full_name = r.nameWithOwner;
     res.private = r.isPrivate;
-    res.owner = r.owner.login;
+    res.owner = {
+      login: r.owner.login
+    };
     res.html_url = r.url;
     res.description = r.description;
     res.fork = r.isFork;
@@ -78,7 +80,7 @@ query($owner: String!, $name: String!) {
     // format: "2015-09-10T02:15:47Z"
     res.created_at = coerceDate(r.createdAt);
     res.updated_at = coerceDate(r.updatedAt);
-    res.pusher_at = coerceDate(r.pushedAt);
+    res.pushed_at = coerceDate(r.pushedAt);
 
     res.homepage = r.homepageUrl; // TODO verify expected URL
     res.size = r.diskUsage;


### PR DESCRIPTION
What this PR does:
* In order to increase the rate limit, enables `fetchRepos` to run using both v3 and v4 of GitHub API concurrently.
* Removes the spinner and use `console.log` instead (spinner doesn't work well with concurrent code)
* Fixes/Improves v4 driver
  * Fixes typo _pusher_at_
  * Fixes response structure for _owner_ field
  * Handles the case when there is no primary language
  * Returns expected error codes when the GraphQL endpoint returns an error

Differences v4 driver compared to v3:
* There is no `webflow` user
* In the `repo` query, the `organization` field is just an empty object instead of containing information. When the owner is not an organization, there is no `organization` field at all.